### PR TITLE
Feat/archiving filtered replication

### DIFF
--- a/tasks/restart_replication.py
+++ b/tasks/restart_replication.py
@@ -110,6 +110,8 @@ def _clear_log_file():
     except FileNotFoundError:
         with open(log_file, "w") as f:
             f.write(f"{NOW} - Log file created\n")
+
+
 def _delete_replicator_db():
     delete_replicator_db_cmd = ['curl', '-X', 'DELETE', replicator_db_url]
     try:
@@ -120,6 +122,7 @@ def _delete_replicator_db():
     except subprocess.CalledProcessError as e:
         with open(log_file, 'a') as log:
             log.write(f"{NOW} - Error deleting _replicator database: {e.stderr}\n")
+
 
 def _create_replicator_db():
     create_replicator_db_cmd = ['curl', '-X', 'PUT', replicator_db_url]

--- a/tasks/restart_replication.py
+++ b/tasks/restart_replication.py
@@ -104,6 +104,7 @@ def _clear_log_file():
 
         if len(lines) > 51:
             with open(log_file, "w") as f:
+                logging.info(f"{NOW} - Log file rotated (50+)")
                 f.write(f"{NOW} - Log file rotated (50+)\n")
 
     except FileNotFoundError:

--- a/tasks/restart_replication.py
+++ b/tasks/restart_replication.py
@@ -1,22 +1,20 @@
 import json
 import subprocess
-import datetime
+from datetime import datetime, timedelta
 import sys
 import logging
+from utils.misc import initialize_archive_settings
 
 # CONFIGS
 logging.basicConfig(level=logging.INFO)
 
 replications_file = "config/replications.config"
-archive_file = "config/archive.config"
+archive_settings = initialize_archive_settings()
 ward_file = "config/department.config"
 log_file = "logs/restart_replication.log"
 
 with open(replications_file) as json_file:
     replication_settings = json.load(json_file)
-
-with open(archive_file) as json_file:
-    archive_settings = json.load(json_file)
 
 with open(ward_file) as json_file:
     wards_data = json.load(json_file)
@@ -50,6 +48,11 @@ replicator_db_url = f"http://{source_user}:{source_pass}@{source_host}:{source_p
 design_id = (source_host).replace('.','')
 sub_directories = ["_lab_test_panels", "_lab_test_type", "_patients", "_users"]
 
+cut_off_days = archive_settings["cut_off_days"] | 7
+BUFF_DURATION_UNIX = int(    (   datetime.now() - timedelta(days=cut_off_days)    )   .timestamp()    )
+
+NOW = datetime.now()
+
 # COMMANDS
 source_to_target_cmd = [
     'curl', '-d', json.dumps({
@@ -74,7 +77,6 @@ target_to_source_cmd =[
 
 # REPLICATION WINDOW
 def _check_replication_window():
-    now = datetime.datetime.now()
 
     START_HOUR = archive_settings["archive_window"]["start_hour"] | 1
     START_MINUTE = archive_settings["archive_window"]["start_minute"] | 0
@@ -86,13 +88,13 @@ def _check_replication_window():
     END_SECOND = archive_settings["archive_window"]["end_second"]   | 0
     END_MICROSECOND = archive_settings["archive_window"]["end_microsecond"] | 0
 
-    start_time = now.replace(hour=START_HOUR, minute=START_MINUTE, second=START_SECOND, microsecond=START_MICROSECOND)
-    end_time = now.replace(hour=END_HOUR, minute=END_MINUTE, second=END_SECOND, microsecond=END_MICROSECOND)
+    start_time = NOW.replace(hour=START_HOUR, minute=START_MINUTE, second=START_SECOND, microsecond=START_MICROSECOND)
+    end_time = NOW.replace(hour=END_HOUR, minute=END_MINUTE, second=END_SECOND, microsecond=END_MICROSECOND)
 
-    if start_time <= now  <= end_time:
+    if start_time <= NOW  <= end_time:
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Replication skipped at {now} as it is within the threshhold time window.\n")
-            logging.info(f"{now} : as it is within the threshhold time window.")
+            log.write(f"{NOW} - Replication skipped at {NOW} as it is within the threshhold time window.\n")
+            logging.info(f"{NOW} : as it is within the threshhold time window.")
         sys.exit(0)
 
 def _clear_log_file():
@@ -102,39 +104,44 @@ def _clear_log_file():
 
         if len(lines) > 51:
             with open(log_file, "w") as f:
-                f.write(f"{datetime.datetime.now()} - Log file rotated (50+)\n")
+                f.write(f"{NOW} - Log file rotated (50+)\n")
 
     except FileNotFoundError:
         with open(log_file, "w") as f:
-            f.write(f"{datetime.datetime.now()} - Log file created\n")
-
+            f.write(f"{NOW} - Log file created\n")
 def _delete_replicator_db():
     delete_replicator_db_cmd = ['curl', '-X', 'DELETE', replicator_db_url]
     try:
         subprocess.run(delete_replicator_db_cmd, check=True, capture_output=True, text=True)
         logging.info(f"Deleting _replicator database if it exists...")
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Deleting _replicator database if it exists...\n")
+            log.write(f"{NOW} - Deleting _replicator database if it exists...\n")
     except subprocess.CalledProcessError as e:
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Error deleting _replicator database: {e.stderr}\n")
+            log.write(f"{NOW} - Error deleting _replicator database: {e.stderr}\n")
 
 def _create_replicator_db():
     create_replicator_db_cmd = ['curl', '-X', 'PUT', replicator_db_url]
     try:
         subprocess.run(create_replicator_db_cmd, check=True, capture_output=True, text=True)
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Created replicator databese:\n")
+            log.write(f"{NOW} - Created replicator databese:\n")
             logging.info(f"Created replicator databese...")
     except subprocess.CalledProcessError as e:
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Error creating _replicator database: {e.stderr}\n")
+            log.write(f"{NOW} - Error creating _replicator database: {e.stderr}\n")
             logging.error(f"Error creating _replicator database: {e.stderr}")
 
 def _create_target_design_doc():
     design_doc = {
         "filters": {
-            f"ward_filter_{design_id}": f"function(doc, req) {{ var wards = {json.dumps(wards)}; return wards.includes(doc.ward); }}"
+            f"ward_filter_{design_id}": f"""
+            function(doc, req) {{
+                var wards = {json.dumps(wards)};
+                var maxValue = {BUFF_DURATION_UNIX};
+                return wards.includes(doc.ward);
+            }}
+        """
         }
     }
 
@@ -145,23 +152,23 @@ def _create_target_design_doc():
     try:
         subprocess.run(create_design_doc_cmd, check=True, capture_output=True, text=True)
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Design document created successfully on the target database\n")
+            log.write(f"{NOW} - Design document created successfully on the target database\n")
             logging.info(f"Design document created successfully on the target database")
 
     except subprocess.CalledProcessError as e:
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Error creating design document: {e.stderr}\n")
+            log.write(f"{NOW} - Error creating design document: {e.stderr}\n")
             logging.error(f"Error creating design document: {e.stderr}")
 
 def _create_replication(command,log_message):
     try:
         subprocess.run(command, check=True, capture_output=True, text=True)
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - {log_message}:\n")
+            log.write(f"{NOW} - {log_message}:\n")
             logging.info(log_message)
     except subprocess.CalledProcessError as e:
         with open(log_file, 'a') as log:
-            log.write(f"{datetime.datetime.now()} - Error: {log_message}\n{e.stderr}\n")
+            log.write(f"{NOW} - Error: {log_message}\n{e.stderr}\n")
             logging.error(f"Error: {log_message}\n{e.stderr}")
 
 def _create_replication_on_subdirs():
@@ -194,12 +201,12 @@ def _create_replication_on_subdirs():
 
         _create_replication(
             idx_source_to_target_cmd,
-            f"{datetime.datetime.now()} - Replication setup: source to target for {suffix if suffix else 'primary'}"
+            f"{NOW} - Replication setup: source to target for {suffix if suffix else 'primary'}"
         )
 
         _create_replication(
             idx_target_to_source_cmd,
-            f"{datetime.datetime.now()} - Replication setup: target to source for {suffix if suffix else 'primary'}"
+            f"{NOW} - Replication setup: target to source for {suffix if suffix else 'primary'}"
         )
 
 # RESTART REPLICATION 

--- a/tasks/restart_replication.py
+++ b/tasks/restart_replication.py
@@ -136,6 +136,32 @@ def _create_replicator_db():
             log.write(f"{NOW} - Error creating _replicator database: {e.stderr}\n")
             logging.error(f"Error creating _replicator database: {e.stderr}")
 
+
+def _get_design_doc_rev():
+    get_desig_doc_cmd = [
+        'curl',
+        '-X', 'GET',
+        '--max-time', '10',
+        f"{target_url}/_design/ward_filter_{design_id}"
+    ]
+    try:
+        result = subprocess.run(get_desig_doc_cmd, check=True, capture_output=True, text=True)
+        doc = json.loads(result.stdout)
+
+        with open(log_file, 'a') as log:
+            if '_rev' in doc:
+                log.write(f"{NOW} - design document exists - _rev {doc['_rev']}\n")
+                return doc['_rev']
+            else:
+                log.write(f"{NOW} - design document does not exist\n")
+                return None
+
+    except subprocess.CalledProcessError as e:
+        with open(log_file, 'a') as log:
+            log.write(f"{NOW} - Error getting the design document: {e.stderr}\n")
+        return None
+
+
 def _create_target_design_doc():
     design_doc = {
         "filters": {
@@ -143,21 +169,34 @@ def _create_target_design_doc():
             function(doc, req) {{
                 var wards = {json.dumps(wards)};
                 var maxValue = {BUFF_DURATION_UNIX};
-                return wards.includes(doc.ward);
+                return wards.includes(doc.ward) && doc.date_ordered > maxValue;
             }}
         """
         }
     }
 
+    _rev = _get_design_doc_rev()
+    _push_msg = "created"
+
     create_design_doc_cmd = [
-        'curl', '-d', json.dumps(design_doc), '-H', 'Content-Type: application/json',
-        '-X', 'PUT', f"{target_url}/_design/ward_filter_{design_id}"
+        'curl',
+        '-d', json.dumps(design_doc),
+        '-H', 'Content-Type: application/json',
+        '-X', 'PUT',
+        '--max-time', '10',
+        f"{target_url}/_design/ward_filter_{design_id}"
     ]
+
+    if _rev:
+        create_design_doc_cmd[-1] += f"?rev={_rev}"
+        _push_msg = "updated"
+
+
     try:
         subprocess.run(create_design_doc_cmd, check=True, capture_output=True, text=True)
         with open(log_file, 'a') as log:
-            log.write(f"{NOW} - Design document created successfully on the target database\n")
-            logging.info(f"Design document created successfully on the target database")
+            log.write(f"{NOW} - Design document {_push_msg} successfully on the target database\n")
+            logging.info(f"Design document {_push_msg} successfully on the target database")
 
     except subprocess.CalledProcessError as e:
         with open(log_file, 'a') as log:

--- a/tasks/restart_replication.py
+++ b/tasks/restart_replication.py
@@ -48,7 +48,7 @@ replicator_db_url = f"http://{source_user}:{source_pass}@{source_host}:{source_p
 design_id = (source_host).replace('.','')
 sub_directories = ["_lab_test_panels", "_lab_test_type", "_patients", "_users"]
 
-cut_off_days = archive_settings["cut_off_days"] | 7
+cut_off_days = archive_settings["cut_off_days"]
 BUFF_DURATION_UNIX = int(    (   datetime.now() - timedelta(days=cut_off_days)    )   .timestamp()    )
 
 NOW = datetime.now()
@@ -78,15 +78,15 @@ target_to_source_cmd =[
 # REPLICATION WINDOW
 def _check_replication_window():
 
-    START_HOUR = archive_settings["archive_window"]["start_hour"] | 1
-    START_MINUTE = archive_settings["archive_window"]["start_minute"] | 0
-    START_SECOND = archive_settings["archive_window"]["start_second"] | 0
-    START_MICROSECOND = archive_settings["archive_window"]["start_microsecond"] | 0
+    START_HOUR = archive_settings["archive_window"]["start_hour"]
+    START_MINUTE = archive_settings["archive_window"]["start_minute"]
+    START_SECOND = archive_settings["archive_window"]["start_second"]
+    START_MICROSECOND = archive_settings["archive_window"]["start_microsecond"]
 
-    END_HOUR = archive_settings["archive_window"]["end_hour"] | 3
-    END_MINUTE = archive_settings["archive_window"]["end_minute"] | 0
-    END_SECOND = archive_settings["archive_window"]["end_second"]   | 0
-    END_MICROSECOND = archive_settings["archive_window"]["end_microsecond"] | 0
+    END_HOUR = archive_settings["archive_window"]["end_hour"]
+    END_MINUTE = archive_settings["archive_window"]["end_minute"]
+    END_SECOND = archive_settings["archive_window"]["end_second"]
+    END_MICROSECOND = archive_settings["archive_window"]["end_microsecond"]
 
     start_time = NOW.replace(hour=START_HOUR, minute=START_MINUTE, second=START_SECOND, microsecond=START_MICROSECOND)
     end_time = NOW.replace(hour=END_HOUR, minute=END_MINUTE, second=END_SECOND, microsecond=END_MICROSECOND)

--- a/tasks/restart_replication.py
+++ b/tasks/restart_replication.py
@@ -116,9 +116,9 @@ def _delete_replicator_db():
     delete_replicator_db_cmd = ['curl', '-X', 'DELETE', replicator_db_url]
     try:
         subprocess.run(delete_replicator_db_cmd, check=True, capture_output=True, text=True)
-        logging.info(f"Deleting _replicator database if it exists...")
+        logging.info(f"Deleting _replicator database if it exists")
         with open(log_file, 'a') as log:
-            log.write(f"{NOW} - Deleting _replicator database if it exists...\n")
+            log.write(f"{NOW} - Deleting _replicator database\n")
     except subprocess.CalledProcessError as e:
         with open(log_file, 'a') as log:
             log.write(f"{NOW} - Error deleting _replicator database: {e.stderr}\n")

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -72,6 +72,17 @@ def initialize_departments():
     return departments
 
 
+
+def initialize_archive_settings():
+    archive_settings = {}
+    try:
+        with open("config/archive.config") as json_file:
+            archive_settings = json.load(json_file)
+    finally:
+        pass
+    return archive_settings
+
+
 def current_facility():
     try:
         with open("config/application.config") as json_file:


### PR DESCRIPTION
The pr improves the existing script `restart_replication.py` which ensures that replication is active by  recreating  the _replicator database.
- This is intentional to ensure a clean state, but it will remove any existing replication jobs.
---
### Changes
-The wards list and cutoff time are loaded from config files (department.config and replications.config) utilizing the utils.misc `wards_settings` and `archive_settings`
- Error handling is included for subprocess calls and missing config keys
- create an abstraction for loading archive setting in `utils.misc.initialize_archive_settings()`
- improve readability by adding in white spaces between statements
- enhancement: include utilizing BUFF_DURATION_UNIX for filter docs based on date_ordered